### PR TITLE
Remove use of lego logger to remove circular dependency

### DIFF
--- a/cmd/hoverdns/main.go
+++ b/cmd/hoverdns/main.go
@@ -20,13 +20,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"runtime"
 	"sync"
 	"time"
 
 	hover "github.com/chickenandpork/hoverdnsapi"
-	"github.com/go-acme/lego/v3/log"
 	"github.com/urfave/cli/v2"
 )
 
@@ -47,7 +47,6 @@ func getClient(username, password, passfile string) *hover.Client {
 
 	return client
 }
-
 
 func main() {
 	var (
@@ -107,7 +106,7 @@ func main() {
 			},
 
 			// "update" adds an Update action to the Actions stack for each domain, then
-                        // executes, so any dependencies such as expanding records don't need to
+			// executes, so any dependencies such as expanding records don't need to
 			// leak out here: just stack up the actions, let the subsys figure it out.
 			{Name: "update",
 				Usage: "update a record in each domain (extra parms for hostname and value)",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/githubnemo/CompileDaemon v1.2.1 // indirect
-	github.com/go-acme/lego/v3 v3.6.0
 	github.com/go-test/deep v1.0.6
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/jpoles1/gopherbadger v2.4.0+incompatible // indirect


### PR DESCRIPTION
As noted in go-acme/lego#1255 this library can create a circular dependency.  Removing it was more straightforward than I thought.